### PR TITLE
Initial work on configurable moving platform

### DIFF
--- a/Assets/elements/moving_platform/moving_platform.gd
+++ b/Assets/elements/moving_platform/moving_platform.gd
@@ -1,0 +1,41 @@
+extends Node2D
+
+export var speed = 60
+export (int, "Up", "Down") var initial_direction
+export var keep_moving = true
+
+var going_up
+var platform
+var area
+
+func set_direction(pos):
+	var area_pos = area.get_pos()
+	var area_extents = area.get_shape(0).get_extents()
+	var top = area_pos.y - area_extents.y
+	var bottom = area_pos.y + area_extents.y
+	
+	# If top/bottom is reached, turn around or stop moving
+	if (not going_up && pos.y >= bottom) || (going_up && pos.y <= top):
+		going_up = !going_up
+		if not keep_moving:
+			set_process(false)
+	
+func _process(delta):
+	var pos = platform.get_pos()
+	set_direction(pos)
+	
+	if not going_up:
+		pos.y += speed * delta
+	else:
+		pos.y -= speed * delta
+	
+	platform.set_pos(pos)
+	
+func _ready():
+	platform = get_node("StaticBody2D")
+	area = get_node("Area2D")
+	going_up = !initial_direction
+
+	printt("initial direction", initial_direction, going_up)
+
+	set_process(true)

--- a/Assets/elements/moving_platform/moving_platform.tscn
+++ b/Assets/elements/moving_platform/moving_platform.tscn
@@ -1,0 +1,57 @@
+[gd_scene load_steps=4 format=1]
+
+[ext_resource path="res://Assets/elements/moving_platform/moving_platform.gd" type="Script" id=1]
+[ext_resource path="res://Assets/sprites/painted_platform.png" type="Texture" id=2]
+
+[sub_resource type="RectangleShape2D" id=1]
+
+custom_solver_bias = 0.0
+extents = Vector2( 150, 150 )
+
+[node name="Node2D" type="Node2D"]
+
+script/script = ExtResource( 1 )
+speed = 60
+initial_direction = 0
+keep_moving = true
+
+[node name="StaticBody2D" type="StaticBody2D" parent="."]
+
+transform/pos = Vector2( 1048.87, 381.823 )
+input/pickable = false
+collision/layers = 1
+collision/mask = 1
+constant_linear_velocity = Vector2( 0, 0 )
+constant_angular_velocity = 0.0
+friction = 1.0
+bounce = 0.0
+
+[node name="Sprite" type="Sprite" parent="StaticBody2D"]
+
+texture = ExtResource( 2 )
+__meta__ = {
+"_edit_lock_": true
+}
+
+[node name="Area2D" type="Area2D" parent="."]
+
+transform/pos = Vector2( 1052.48, 360.361 )
+input/pickable = true
+shapes/0/shape = SubResource( 1 )
+shapes/0/transform = Matrix32( 1, 0, 0, 1, 0, 0 )
+shapes/0/trigger = true
+gravity_vec = Vector2( 0, 1 )
+gravity = 98.0
+linear_damp = 0.1
+angular_damp = 1.0
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
+
+shape = SubResource( 1 )
+trigger = true
+_update_shape_index = 0
+__meta__ = {
+"_edit_lock_": true
+}
+
+


### PR DESCRIPTION
A very basic moving platform with editor script variables for setting speed, initial direction and whether it should turn around or stop moving once the top or bottom has been reached.

To make this useful when building levels, it must be possible to set the platform sprite to use (and the script will probably need logic to set the size of the staticbody depending on the sprite size), and the Area2D node should be moved out of the scene and be set in the level after the moving platform has been instanced, so that it's easy to define the "elevator shaft".