### PR TITLE
Make moving_platform more general purpose

### DIFF
--- a/Assets/elements/moving_platform/moving_platform.gd
+++ b/Assets/elements/moving_platform/moving_platform.gd
@@ -19,6 +19,9 @@ func set_keep_moving(new_keep_moving):
 	keep_moving = new_keep_moving
 
 func set_extents_size(new_size, width=true):
+	# Shape might not have been set yet (issue #14)
+	if not area:
+		return
 	var shape = area.get_shape(0)
 	var extents = shape.get_extents()
 	if width:
@@ -49,6 +52,16 @@ func set_direction(pos):
 			set_process(false)
 	
 func _process(delta):
+	# TODO: Unset platform variable when child is removed
+	if not platform:
+		for child in get_children():
+			if child.is_type("PhysicsBody2D"):
+				platform = child
+				platform.set_pos(self.get_pos())
+
+	if not platform:
+		return
+
 	var pos = platform.get_pos()
 	set_direction(pos)
 	
@@ -60,10 +73,9 @@ func _process(delta):
 		pos.y -= speed * delta
 
 	platform.set_pos(pos)
-
+	
 func _ready():
-	platform = get_node("Platform")
 	area = get_node("Area2D")
 	going_up = !initial_direction
-
+	
 	set_process(true)

--- a/Assets/elements/moving_platform/moving_platform.tscn
+++ b/Assets/elements/moving_platform/moving_platform.tscn
@@ -1,33 +1,27 @@
-[gd_scene load_steps=4 format=1]
+[gd_scene load_steps=3 format=1]
 
 [ext_resource path="res://Assets/elements/moving_platform/moving_platform.gd" type="Script" id=1]
-[ext_resource path="res://Assets/elements/platform/platform.tscn" type="PackedScene" id=2]
 
 [sub_resource type="RectangleShape2D" id=1]
 
 custom_solver_bias = 0.0
-extents = Vector2( 170, 300 )
-extents = Vector2( 170, 290 )
+extents = Vector2( 150, 300 )
 
 [node name="Moving platform" type="Node2D"]
 
 script/script = ExtResource( 1 )
-speed = 60
+speed = 200
 initial_direction = 0
 keep_moving = true
 width = 170
 height = 300
-
-[node name="Platform" parent="." instance=ExtResource( 2 )]
-
-transform/pos = Vector2( 0, 0 )
 
 [node name="Area2D" type="Area2D" parent="."]
 
 input/pickable = true
 shapes/0/shape = SubResource( 1 )
 shapes/0/transform = Matrix32( 1, 0, 0, 1, 0, 0 )
-shapes/0/trigger = true
+shapes/0/trigger = false
 gravity_vec = Vector2( 0, 1 )
 gravity = 98.0
 linear_damp = 0.1
@@ -36,7 +30,7 @@ angular_damp = 1.0
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
 
 shape = SubResource( 1 )
-trigger = true
+trigger = false
 _update_shape_index = 0
 __meta__ = {
 "_edit_lock_": true


### PR DESCRIPTION
This commit should close #16.

The scene has also been changed to be more generic and should be able to move any PhysicsBody2D child. It can only move one though, and it should be instanced as a direct child of the node.

To make the moving_platform (which should probably be renamed to platform_mover or body_mover or something like that) align with the body being moved, both should be instanced before either are moved. By setting speed to 0, it's easy to drag the two together.

For now, removing a child and then instancing another does not work, since the variable 'platform' does not get updated with a reference to the new PhysicsBody2D node.